### PR TITLE
chore: update dependency tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 node_modules
 dist
 build
-package-lock.json
 coverage
 .eslintcache

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,24 +41,24 @@
 			}
 		},
 		"@babel/compat-data": {
-			"version": "7.17.0",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.0.tgz",
-			"integrity": "sha512-392byTlpGWXMv4FbyWw3sAZ/FrW/DrwqLGXpy0mbyNe9Taqv1mg9yON5/o0cnr8XYCkFTZbC1eV+c+LAROgrng==",
+			"version": "7.17.7",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.7.tgz",
+			"integrity": "sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ==",
 			"dev": true
 		},
 		"@babel/core": {
-			"version": "7.17.5",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.5.tgz",
-			"integrity": "sha512-/BBMw4EvjmyquN5O+t5eh0+YqB3XXJkYD2cjKpYtWOfFy4lQ4UozNSmxAcWT8r2XtZs0ewG+zrfsqeR15i1ajA==",
+			"version": "7.17.7",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.7.tgz",
+			"integrity": "sha512-djHlEfFHnSnTAcPb7dATbiM5HxGOP98+3JLBZtjRb5I7RXrw7kFRoG2dXM8cm3H+o11A8IFH/uprmJpwFynRNQ==",
 			"dev": true,
 			"requires": {
 				"@ampproject/remapping": "^2.1.0",
 				"@babel/code-frame": "^7.16.7",
-				"@babel/generator": "^7.17.3",
-				"@babel/helper-compilation-targets": "^7.16.7",
-				"@babel/helper-module-transforms": "^7.16.7",
-				"@babel/helpers": "^7.17.2",
-				"@babel/parser": "^7.17.3",
+				"@babel/generator": "^7.17.7",
+				"@babel/helper-compilation-targets": "^7.17.7",
+				"@babel/helper-module-transforms": "^7.17.7",
+				"@babel/helpers": "^7.17.7",
+				"@babel/parser": "^7.17.7",
 				"@babel/template": "^7.16.7",
 				"@babel/traverse": "^7.17.3",
 				"@babel/types": "^7.17.0",
@@ -70,9 +70,9 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.17.3",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.3.tgz",
-			"integrity": "sha512-+R6Dctil/MgUsZsZAkYgK+ADNSZzJRRy0TvY65T71z/CR854xHQ1EweBYXdfT+HNeN7w0cSJJEzgxZMv40pxsg==",
+			"version": "7.17.7",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
+			"integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.17.0",
@@ -100,12 +100,12 @@
 			}
 		},
 		"@babel/helper-compilation-targets": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz",
-			"integrity": "sha512-mGojBwIWcwGD6rfqgRXVlVYmPAv7eOpIemUG3dGnDdCY4Pae70ROij3XmfrH6Fa1h1aiDylpglbZyktfzyo/hA==",
+			"version": "7.17.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.7.tgz",
+			"integrity": "sha512-UFzlz2jjd8kroj0hmCFV5zr+tQPi1dpC2cRsDV/3IEW8bJfCPrPpmcSN6ZS8RqIq4LXcmpipCQFPddyFA5Yc7w==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.16.4",
+				"@babel/compat-data": "^7.17.7",
 				"@babel/helper-validator-option": "^7.16.7",
 				"browserslist": "^4.17.5",
 				"semver": "^6.3.0"
@@ -200,12 +200,12 @@
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.7.tgz",
-			"integrity": "sha512-VtJ/65tYiU/6AbMTDwyoXGPKHgTsfRarivm+YbB5uAzKUyuPjgZSgAFeG87FCigc7KNHu2Pegh1XIT3lXjvz3Q==",
+			"version": "7.17.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.17.7.tgz",
+			"integrity": "sha512-thxXgnQ8qQ11W2wVUObIqDL4p148VMxkt5T/qpN5k2fboRyzFGFmKsTGViquyM5QHKUy48OZoca8kw4ajaDPyw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.16.7"
+				"@babel/types": "^7.17.0"
 			}
 		},
 		"@babel/helper-module-imports": {
@@ -218,14 +218,14 @@
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.17.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.6.tgz",
-			"integrity": "sha512-2ULmRdqoOMpdvkbT8jONrZML/XALfzxlb052bldftkicAUy8AxSCkD5trDPQcwHNmolcl7wP6ehNqMlyUw6AaA==",
+			"version": "7.17.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.7.tgz",
+			"integrity": "sha512-VmZD99F3gNTYB7fJRDTi+u6l/zxY0BE6OIxPSU7a50s6ZUQkHwSDmV92FfM+oCG0pZRVojGYhkR8I0OGeCVREw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-environment-visitor": "^7.16.7",
 				"@babel/helper-module-imports": "^7.16.7",
-				"@babel/helper-simple-access": "^7.16.7",
+				"@babel/helper-simple-access": "^7.17.7",
 				"@babel/helper-split-export-declaration": "^7.16.7",
 				"@babel/helper-validator-identifier": "^7.16.7",
 				"@babel/template": "^7.16.7",
@@ -273,12 +273,12 @@
 			}
 		},
 		"@babel/helper-simple-access": {
-			"version": "7.16.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz",
-			"integrity": "sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==",
+			"version": "7.17.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.17.7.tgz",
+			"integrity": "sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.16.7"
+				"@babel/types": "^7.17.0"
 			}
 		},
 		"@babel/helper-skip-transparent-expression-wrappers": {
@@ -324,13 +324,13 @@
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.17.2",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.2.tgz",
-			"integrity": "sha512-0Qu7RLR1dILozr/6M0xgj+DFPmi6Bnulgm9M8BVa9ZCWxDqlSnqt3cf8IDPB5m45sVXUZ0kuQAgUrdSFFH79fQ==",
+			"version": "7.17.7",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.7.tgz",
+			"integrity": "sha512-TKsj9NkjJfTBxM7Phfy7kv6yYc4ZcOo+AaWGqQOKTPDOmcGkIFb5xNA746eKisQkm4yavUYh4InYM9S+VnO01w==",
 			"dev": true,
 			"requires": {
 				"@babel/template": "^7.16.7",
-				"@babel/traverse": "^7.17.0",
+				"@babel/traverse": "^7.17.3",
 				"@babel/types": "^7.17.0"
 			}
 		},
@@ -346,9 +346,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.17.3",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.3.tgz",
-			"integrity": "sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA==",
+			"version": "7.17.7",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.7.tgz",
+			"integrity": "sha512-bm3AQf45vR4gKggRfvJdYJ0gFLoCbsPxiFLSH6hTVYABptNHY6l9NrhnucVjQ/X+SPtLANT9lc0fFhikj+VBRA==",
 			"dev": true
 		},
 		"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
@@ -737,9 +737,9 @@
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.17.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.17.3.tgz",
-			"integrity": "sha512-dDFzegDYKlPqa72xIlbmSkly5MluLoaC1JswABGktyt6NTXSBcUuse/kWE/wvKFWJHPETpi158qJZFS3JmykJg==",
+			"version": "7.17.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.17.7.tgz",
+			"integrity": "sha512-XVh0r5yq9sLR4vZ6eVZe8FKfIcSgaTBxVBRSYokRj2qksf6QerYnTxz9/GTuKTH/n/HwLP7t6gtlybHetJ/6hQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.16.7"
@@ -824,14 +824,14 @@
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.16.8",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.16.8.tgz",
-			"integrity": "sha512-oflKPvsLT2+uKQopesJt3ApiaIS2HW+hzHFcwRNtyDGieAeC/dIHZX8buJQ2J2X1rxGPy4eRcUijm3qcSPjYcA==",
+			"version": "7.17.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.17.7.tgz",
+			"integrity": "sha512-ITPmR2V7MqioMJyrxUo2onHNC3e+MvfFiFIR0RP21d3PtlVb6sfzoxNKiphSZUOM9hEIdzCcZe83ieX3yoqjUA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-transforms": "^7.16.7",
+				"@babel/helper-module-transforms": "^7.17.7",
 				"@babel/helper-plugin-utils": "^7.16.7",
-				"@babel/helper-simple-access": "^7.16.7",
+				"@babel/helper-simple-access": "^7.17.7",
 				"babel-plugin-dynamic-import-node": "^2.3.3"
 			}
 		},
@@ -1174,9 +1174,9 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.17.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
-			"integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+			"version": "7.17.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.7.tgz",
+			"integrity": "sha512-L6rvG9GDxaLgFjg41K+5Yv9OMrU98sWe+Ykmc6FDJW/+vYZMhdOMKkISgzptMaERHvS2Y2lw9MDRm2gHhlQQoA==",
 			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
@@ -1601,9 +1601,9 @@
 			}
 		},
 		"@types/json-schema": {
-			"version": "7.0.9",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-			"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+			"version": "7.0.10",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.10.tgz",
+			"integrity": "sha512-BLO9bBq59vW3fxCpD4o0N4U+DXsvwvIcl+jofw0frQo/GrBFC+/jRZj1E7kgp6dvTyNmA4y6JCV5Id/r3mNP5A==",
 			"dev": true
 		},
 		"@types/json5": {
@@ -1831,9 +1831,9 @@
 			}
 		},
 		"ansi-regex": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-			"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+			"integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
 			"dev": true
 		},
 		"ansi-styles": {
@@ -2495,13 +2495,13 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.20.0",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.0.tgz",
-			"integrity": "sha512-bnpOoa+DownbciXj0jVGENf8VYQnE2LNWomhYuCsMmmx9Jd9lwq0WXODuwpSsp8AVdKM2/HorrzxAfbKvWTByQ==",
+			"version": "4.20.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
+			"integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30001313",
-				"electron-to-chromium": "^1.4.76",
+				"caniuse-lite": "^1.0.30001317",
+				"electron-to-chromium": "^1.4.84",
 				"escalade": "^3.1.1",
 				"node-releases": "^2.0.2",
 				"picocolors": "^1.0.0"
@@ -2606,9 +2606,9 @@
 			"dev": true
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001314",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001314.tgz",
-			"integrity": "sha512-0zaSO+TnCHtHJIbpLroX7nsD+vYuOVjl3uzFbJO1wMVbuveJA0RK2WcQA9ZUIOiO0/ArMiMgHJLxfEZhQiC0kw==",
+			"version": "1.0.30001317",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001317.tgz",
+			"integrity": "sha512-xIZLh8gBm4dqNX0gkzrBeyI86J2eCjWzYAs40q88smG844YIrN4tVQl/RhquHvKEKImWWFIVh1Lxe5n1G/N+GQ==",
 			"dev": true
 		},
 		"capture-exit": {
@@ -3436,9 +3436,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.4.80",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.80.tgz",
-			"integrity": "sha512-COsbJCGVYCc/aAY4cd94x1Js3q0r406YKGbdL8LXHg0O9dEjuFEFU/vZneRxBxKo/f1lLHi0YyAR7sbFM+i8Bg==",
+			"version": "1.4.86",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.86.tgz",
+			"integrity": "sha512-EVTZ+igi8x63pK4bPuA95PXIs2b2Cowi3WQwI9f9qManLiZJOD1Lash1J3W4TvvcUCcIR4o/rgi9o8UicXSO+w==",
 			"dev": true
 		},
 		"elegant-spinner": {
@@ -3926,9 +3926,9 @@
 			"dev": true
 		},
 		"eslint-plugin-react": {
-			"version": "7.29.3",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.29.3.tgz",
-			"integrity": "sha512-MzW6TuCnDOcta67CkpDyRfRsEVx9FNMDV8wZsDqe1luHPdGTrQIUaUXD27Ja3gHsdOIs/cXzNchWGlqm+qRVRg==",
+			"version": "7.29.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.29.4.tgz",
+			"integrity": "sha512-CVCXajliVh509PcZYRFyu/BoUEz452+jtQJq2b3Bae4v3xBUWPLCmtmBM+ZinG4MzwmxJgJ2M5rMqhqLVn7MtQ==",
 			"dev": true,
 			"requires": {
 				"array-includes": "^3.1.4",
@@ -7509,18 +7509,18 @@
 			}
 		},
 		"mime-db": {
-			"version": "1.51.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-			"integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
 			"dev": true
 		},
 		"mime-types": {
-			"version": "2.1.34",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
-			"integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
 			"dev": true,
 			"requires": {
-				"mime-db": "1.51.0"
+				"mime-db": "1.52.0"
 			}
 		},
 		"mimic-fn": {
@@ -8313,9 +8313,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
-			"integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.0.tgz",
+			"integrity": "sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==",
 			"dev": true
 		},
 		"pretty-format": {
@@ -10496,9 +10496,9 @@
 			"dev": true
 		},
 		"tsconfig-paths": {
-			"version": "3.13.0",
-			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.13.0.tgz",
-			"integrity": "sha512-nWuffZppoaYK0vQ1SQmkSsQzJoHA4s6uzdb2waRpD806x9yfq153AdVsWz4je2qZcW+pENrMQXbGQ3sMCkXuhw==",
+			"version": "3.14.0",
+			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.0.tgz",
+			"integrity": "sha512-cg/1jAZoL57R39+wiw4u/SCC6Ic9Q5NqjBOb+9xISedOYurfog9ZNmKJSxAnb2m/5Bq4lE9lhUcau33Ml8DM0g==",
 			"dev": true,
 			"requires": {
 				"@types/json5": "^0.0.29",


### PR DESCRIPTION
Updated dependency tree for the lock file of your node project. 

By regenerating the lockfiles, the dependency tree has been updated to pull in the latest packages that match the dependency ranges in `package.json`. For each of those dependencies, the sub-dependencies are updated and so on. 

None of these updates should be a breaking change, since they respect the [version ranges](https://semver.npmjs.com/). They'll potentially save you and your team a lot of time by preventing `Dependabot` vulnerability alerts that you'd have to deal with manually otherwise. 

Good luck!

_This workflow was created and is maintained by the [Developer Productivity](https://tradeshift.slack.com/archives/C78TDU0FJ) team._