### PR TITLE
fix(publish):change npm token

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,7 +72,7 @@ pipeline {
 
         stage('Semantic release') {
             environment {
-                NPM_TOKEN = credentials 'jenkins-public-npm-rw-token'
+                NPM_TOKEN = credentials 'tradeshiftci-npm-readwrite-token'
             }
             steps {
                 semanticVersion()


### PR DESCRIPTION
attempt to fix npm publish by changing npm token from` credentials 'jenkins-public-npm-rw-token'` to `credentials 'tradeshiftci-npm-readwrite-token'`